### PR TITLE
Bug: Sessions hang indefinitely — missing `run` command after init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,16 @@ async function main() {
         const applied = await toolsContext.pendingBreakpoints.applyToSession(session);
         logger.info(`Applied ${applied.length} breakpoints to session ${session.id}`);
       }
+
+      // Continue execution — PHP will break at breakpoints or run to completion
+      const result = await session.run();
+
+      // When script finishes (status=stopping), send stop to release PHP process.
+      // DBGp "stopping" state means the script completed but the engine is waiting
+      // for client acknowledgment before shutting down.
+      if (result.status === 'stopping') {
+          await session.stop();
+      }
     } catch (error) {
       logger.error('Failed to create session:', error);
       connection.close();


### PR DESCRIPTION
## Summary

When Xdebug connects to xdebug-mcp, the PHP process hangs forever. The MCP server accepts the connection and negotiates features but never sends a `run` command, leaving PHP paused at the first line.

## Expected behavior

After session initialization and breakpoint application, the server should send `run` so PHP continues execution. If a breakpoint is hit, the session pauses there. If no breakpoints match, the request completes normally.

This is how PhpStorm and other DBGp clients work: `init` → `feature_set` → `breakpoint_set` → `run`.

## Actual behavior

The `connection` handler in `src/index.ts` creates the session, applies pending breakpoints, then **returns without sending any execution command**. The PHP process stays paused indefinitely, blocking the HTTP request.

## Root cause

Two missing DBGp commands in the `connection` handler (`src/index.ts`, compiled as `dist/index.js` lines 29-47):

```js
dbgpServer.on('connection', async (connection) => {
    try {
        const session = await sessionManager.createSession(connection);

        const pendingCount = toolsContext.pendingBreakpoints.count;
        if (pendingCount > 0) {
            const applied = await toolsContext.pendingBreakpoints.applyToSession(session);
        }
        // BUG 1: no `run` command is sent — PHP stays paused at first line forever
        // BUG 2: no `stop` command after script completion — PHP process held in
        //         DBGp "stopping" state, blocking the HTTP response
    } catch (error) {
        logger.error('Failed to create session:', error);
        connection.close();
    }
});
```

## Suggested fix

Add `await session.run()` after breakpoint application, then send `stop` when the script finishes:

```js
dbgpServer.on('connection', async (connection) => {
    logger.info(`New Xdebug connection: ${connection.id}`);
    try {
        const session = await sessionManager.createSession(connection);

        const pendingCount = toolsContext.pendingBreakpoints.count;
        if (pendingCount > 0) {
            const applied = await toolsContext.pendingBreakpoints.applyToSession(session);
        }

        // Continue execution — PHP will break at breakpoints or run to completion
        const result = await session.run();

        // When script finishes (status=stopping), send stop to release PHP process.
        // DBGp "stopping" state means the script completed but the engine is waiting
        // for client acknowledgment before shutting down.
        if (result.status === 'stopping') {
            await session.stop();
        }
    } catch (error) {
        logger.error('Failed to create session:', error);
        connection.close();
    }
});
```

Two changes are needed:

1. **`await session.run()`** — sends the DBGp `run` command so Xdebug continues PHP execution. If breakpoints are set, PHP will pause when it hits one (status=`break`). If no breakpoints match, the script runs to completion (status=`stopping`).

2. **`await session.stop()`** when status is `stopping` — acknowledges script completion. Without this, Xdebug holds the PHP process in `stopping` state indefinitely, blocking the HTTP response from being sent to the client.

### Verified behavior after fix

- Requests complete in ~286ms (vs infinite hang before)
- Breakpoints still work when set via MCP tools
- Session is properly cleaned up after script completion

## Impact

- Every HTTP request routed through a container with `XDEBUG_TRIGGER` set hangs until the TCP connection times out or is manually killed
- Makes it impossible to use xdebug-mcp alongside always-on Xdebug trigger mode (common in Docker dev setups)
- `COMMAND_TIMEOUT` (default 30s) does not help — it only applies to command responses, not the initial session stall

## Reproduction

1. Configure a PHP container with Xdebug pointing to the host where xdebug-mcp listens
2. Set `XDEBUG_TRIGGER=PHPSTORM` as an env var or cookie
3. Make any HTTP request — it hangs indefinitely
4. No breakpoints need to be set

## Environment

- xdebug-mcp: 1.1.0
- Xdebug: 3.5.1
- PHP: 8.4 (FrankenPHP)
- Node: 20.11.0

## Workaround

Don't share same debug container between human and mcp, set up separate one for mcp