### PR TITLE
Feature: add DBGp proxy registration support and multi-agent setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ XDEBUG_PORT=9003
 # Host to bind (use 0.0.0.0 for all interfaces)
 XDEBUG_HOST=0.0.0.0
 
+# Optional DBGp proxy registration (TCP listener mode only)
+# When using a proxy on 9003, set XDEBUG_PORT to a separate callback port such as 9006
+# DBGP_PROXY_HOST=127.0.0.1
+# DBGP_PROXY_PORT=9001
+# DBGP_IDEKEY=mcp
+# DBGP_PROXY_ALLOW_FALLBACK=false
+
 # Command timeout in milliseconds (default: 30000)
 COMMAND_TIMEOUT=30000
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,139 @@ When debugging PHP in Docker containers, you need path mappings to translate con
 }
 ```
 
+### With DBGp Proxy Registration
+
+If you already use a DBGp proxy, xdebug-mcp can register itself on startup in the same way a traditional IDE does. Proxy registration is optional and only activates when all proxy environment variables are present.
+
+```json
+{
+  "mcpServers": {
+    "xdebug": {
+      "command": "xdebug-mcp",
+      "env": {
+        "XDEBUG_PORT": "9006",
+        "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+Notes:
+- Proxy registration requires TCP listener mode. It does not work when `XDEBUG_SOCKET_PATH` is set.
+- In proxy mode, keep PHP/Xdebug pointed at the proxy endpoint and give xdebug-mcp its own callback port such as `9006`.
+- Do not reuse the proxy's client-facing port for `XDEBUG_PORT`.
+- On startup, xdebug-mcp sends `proxyinit -p <listen-port> -k <idekey> -m 1`.
+- On shutdown, xdebug-mcp sends `proxystop -k <idekey>`.
+- If `DBGP_PROXY_ALLOW_FALLBACK=false`, startup fails when proxy registration fails.
+- If `DBGP_PROXY_ALLOW_FALLBACK=true`, the server logs the error and continues in direct-listener mode.
+
+### DBGp Proxy Configuration Guide
+
+Use this mode when PHP should connect to a DBGp proxy, and the proxy should route sessions to xdebug-mcp by IDE key.
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `XDEBUG_PORT` | Yes | TCP callback port where `xdebug-mcp` listens for proxied DBGp sessions. Example: `9006`. This is **not** the proxy's port. |
+| `XDEBUG_HOST` | No | Interface for the local callback listener. Defaults to `0.0.0.0`. |
+| `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
+| `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` / `proxystop`. Example: `9001`. |
+| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm, for example `mcp`. |
+| `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), keep running in direct-listener mode if proxy registration fails. When `false`, exit startup on registration failure. |
+
+Important constraints:
+- `XDEBUG_SOCKET_PATH` cannot be used together with DBGp proxy registration in the current implementation.
+- `XDEBUG_PORT` is the MCP callback listener port. PHP/Xdebug should still connect to the proxy's client-facing port.
+- Use a dedicated IDE key for xdebug-mcp. Do not reuse the same IDE key as PhpStorm.
+
+#### MCP Configuration Examples
+
+**Installed package:**
+
+```json
+{
+  "mcpServers": {
+    "xdebug": {
+      "command": "xdebug-mcp",
+      "env": {
+        "XDEBUG_PORT": "9006",
+        "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+**Run from a local source checkout:**
+
+```json
+{
+  "mcpServers": {
+    "xdebug": {
+      "command": "node",
+      "args": ["/absolute/path/to/xdebug-mcp/dist/index.js"],
+      "env": {
+        "XDEBUG_PORT": "9006",
+        "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+Use the `node .../dist/index.js` form when running an unpublished local branch.
+
+#### How Registration Works
+
+1. `xdebug-mcp` starts its local TCP listener on `XDEBUG_HOST:XDEBUG_PORT`.
+2. If `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` are present, it opens a control connection to the DBGp proxy.
+3. It sends:
+   - `proxyinit -p <XDEBUG_PORT> -k <DBGP_IDEKEY> -m 1`
+4. The proxy stores that registration and routes matching IDE-key sessions back to `xdebug-mcp`.
+5. On shutdown, `xdebug-mcp` sends:
+   - `proxystop -k <DBGP_IDEKEY>`
+
+#### PHP/Xdebug Side In Proxy Mode
+
+When using a DBGp proxy, PHP should point to the proxy, not directly to `xdebug-mcp`:
+
+```ini
+[xdebug]
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.start_with_request=trigger
+xdebug.client_host=127.0.0.1
+xdebug.client_port=9003
+```
+
+Then trigger the request with the IDE key registered for `xdebug-mcp`, for example:
+- `XDEBUG_TRIGGER=mcp`
+- `XDEBUG_SESSION=mcp`
+
+#### DBGp Proxy Binary / Download
+
+The official Xdebug DBGp proxy documentation, source, and download guidance are here:
+- https://xdebug.org/docs/dbgpProxy
+
+Use that page for installation details and the current recommended binary/source distribution method for the proxy.
+
 ## PHP/Xdebug Configuration
 
 ### php.ini (or xdebug.ini)
@@ -355,9 +488,13 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode) |
+| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode). In DBGp proxy mode, set this to a separate callback port such as `9006`, not the proxy's client-facing port |
 | `XDEBUG_HOST` | `0.0.0.0` | Host to bind (TCP mode) |
 | `XDEBUG_SOCKET_PATH` | - | Unix domain socket path (e.g., `/tmp/xdebug.sock`). When set, uses Unix socket instead of TCP |
+| `DBGP_PROXY_HOST` | - | DBGp proxy host for optional IDE registration |
+| `DBGP_PROXY_PORT` | - | DBGp proxy port for optional IDE registration (typically `9001`) |
+| `DBGP_IDEKEY` | - | IDE key to register with the DBGp proxy |
+| `DBGP_PROXY_ALLOW_FALLBACK` | `true` | Continue in direct-listener mode when proxy registration fails |
 | `COMMAND_TIMEOUT` | `30000` | Command timeout in milliseconds |
 | `PATH_MAPPINGS` | - | JSON object mapping container to host paths |
 | `MAX_DEPTH` | `3` | Max depth for variable inspection |
@@ -402,6 +539,7 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 **Connection Options:**
 - **TCP (Default):** `xdebug.client_host=127.0.0.1` + `XDEBUG_PORT=9003`
 - **Unix Socket:** `xdebug.client_host=unix:///tmp/xdebug.sock` + `XDEBUG_SOCKET_PATH=/tmp/xdebug.sock`
+- **DBGp Proxy:** Keep xdebug-mcp listening on TCP, set `XDEBUG_PORT` to a separate callback port such as `9006`, and set `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` so the server registers itself with your proxy on startup
 
 ## Troubleshooting
 
@@ -431,6 +569,22 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 3. **Socket path in php.ini:**
    - Correct: `xdebug.client_host=unix:///tmp/xdebug.sock`
    - Wrong: `xdebug.client_host=unix:/tmp/xdebug.sock` (missing one `/`)
+
+### DBGp proxy issues
+
+1. **Server starts but never registers with the proxy**
+   - Set `LOG_LEVEL=debug`
+   - Verify `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` are all present
+2. **Proxy mode with Unix sockets**
+   - Remove `XDEBUG_SOCKET_PATH`
+   - DBGp proxy registration requires TCP listener mode
+3. **Proxy registration failure should stop startup**
+   - Set `DBGP_PROXY_ALLOW_FALLBACK=false`
+4. **Proxy cannot route back to xdebug-mcp**
+   - Do not set `XDEBUG_PORT` to the proxy's client-facing port
+   - Use a separate callback port such as `9006`
+   - Make sure the MCP server's `XDEBUG_PORT` is reachable from the proxy
+   - Remember that the proxy uses the registration connection's source address plus the `-p` port
 
 ### Breakpoints not hitting
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Notes:
 - Do not reuse the proxy's client-facing port for `XDEBUG_PORT`.
 - On startup, xdebug-mcp sends `proxyinit -p <listen-port> -k <idekey> -m 1`.
 - On shutdown, xdebug-mcp sends `proxystop -k <idekey>`.
+- In proxy mode, give `xdebug-mcp` a little extra time to boot and register before expecting proxied sessions to route successfully.
 - If `DBGP_PROXY_ALLOW_FALLBACK=false`, startup fails when proxy registration fails.
 - If `DBGP_PROXY_ALLOW_FALLBACK=true`, the server logs the error and continues in direct-listener mode.
 - In fallback mode, `xdebug-mcp` still starts successfully and behaves like a normal direct listener even though proxy registration did not succeed.
@@ -228,6 +229,8 @@ Do not install `xdebug-mcp` behind an MCP proxy or bundler in this setup. The un
 4. The proxy stores that registration and routes matching IDE-key sessions back to `xdebug-mcp`.
 5. On shutdown, `xdebug-mcp` sends:
    - `proxystop -k <DBGP_IDEKEY>`
+
+Depending on your environment, this registration step can add a small startup delay, so give the MCP server a moment to finish booting before expecting the proxy to route sessions to it.
 
 #### PHP/Xdebug Side In Proxy Mode
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Notes:
 - On shutdown, xdebug-mcp sends `proxystop -k <idekey>`.
 - If `DBGP_PROXY_ALLOW_FALLBACK=false`, startup fails when proxy registration fails.
 - If `DBGP_PROXY_ALLOW_FALLBACK=true`, the server logs the error and continues in direct-listener mode.
+- In fallback mode, `xdebug-mcp` still starts successfully and behaves like a normal direct listener even though proxy registration did not succeed.
 - If you run multiple AI agents at the same time, each `xdebug-mcp` instance must use a unique `DBGP_IDEKEY` and a unique `XDEBUG_PORT`.
 - Example values: Warp = `warp-mcp` on `9006`, Claude Code = `claude-mcp` on `9007`, Codex = `codex-mcp` on `9008`.
 - Do not install `xdebug-mcp` behind an MCP proxy or bundler when you need unique per-agent registrations. Register `xdebug-mcp` directly in each agent instead.
@@ -149,7 +150,7 @@ Use this mode when PHP should connect to a DBGp proxy, and the proxy should rout
 | `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
 | `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` / `proxystop`. Example: `9001`. |
 | `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and distinct from every other running agent, for example `warp-mcp`, `claude-mcp`, or `codex-mcp`. |
-| `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), keep running in direct-listener mode if proxy registration fails. When `false`, exit startup on registration failure. |
+| `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), keep running in direct-listener mode if proxy registration fails, so `xdebug-mcp` still starts as a normal direct listener. When `false`, exit startup on registration failure. |
 
 Important constraints:
 - `XDEBUG_SOCKET_PATH` cannot be used together with DBGp proxy registration in the current implementation.

--- a/README.md
+++ b/README.md
@@ -103,161 +103,14 @@ When debugging PHP in Docker containers, you need path mappings to translate con
 
 ### With DBGp Proxy Registration
 
-If you already use a DBGp proxy, xdebug-mcp can register itself on startup in the same way a traditional IDE does. Proxy registration is optional and only activates when all proxy environment variables are present.
+If you already use a DBGp proxy, keep [`mcp-config.example.json`](./mcp-config.example.json) as the default direct-listener example and start from [`mcp-config.proxy.example.json`](./mcp-config.proxy.example.json) for proxy registration.
 
-```json
-{
-  "mcpServers": {
-    "xdebug": {
-      "command": "xdebug-mcp",
-      "env": {
-        "XDEBUG_PORT": "9006",
-        "XDEBUG_HOST": "0.0.0.0",
-        "DBGP_PROXY_HOST": "127.0.0.1",
-        "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "warp-mcp",
-        "DBGP_PROXY_ALLOW_FALLBACK": "false",
-        "LOG_LEVEL": "info"
-      }
-    }
-  }
-}
-```
+Proxy mode requires:
+- TCP listener mode for `xdebug-mcp` (not `XDEBUG_SOCKET_PATH`)
+- a unique callback port such as `9006`, `9007`, or `9008` for `XDEBUG_PORT`
+- `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY`
 
-Notes:
-- Proxy registration requires TCP listener mode. It does not work when `XDEBUG_SOCKET_PATH` is set.
-- In proxy mode, keep PHP/Xdebug pointed at the proxy endpoint and give xdebug-mcp its own callback port such as `9006`.
-- Do not reuse the proxy's client-facing port for `XDEBUG_PORT`.
-- On startup, xdebug-mcp sends `proxyinit -p <listen-port> -k <idekey> -m 1`.
-- On shutdown, xdebug-mcp sends `proxystop -k <idekey>`.
-- In proxy mode, give `xdebug-mcp` a little extra time to boot and register before expecting proxied sessions to route successfully.
-- If `DBGP_PROXY_ALLOW_FALLBACK=false`, startup fails when proxy registration fails.
-- If `DBGP_PROXY_ALLOW_FALLBACK=true`, the server logs the error and continues in direct-listener mode.
-- In fallback mode, `xdebug-mcp` still starts successfully and behaves like a normal direct listener even though proxy registration did not succeed.
-- If you run multiple AI agents at the same time, each `xdebug-mcp` instance must use a unique `DBGP_IDEKEY` and a unique `XDEBUG_PORT`.
-- Example values: Warp = `warp-mcp` on `9006`, Claude Code = `claude-mcp` on `9007`, Codex = `codex-mcp` on `9008`.
-- Do not install `xdebug-mcp` behind an MCP proxy or bundler when you need unique per-agent registrations. Register `xdebug-mcp` directly in each agent instead.
-
-### DBGp Proxy Configuration Guide
-
-Use this mode when PHP should connect to a DBGp proxy, and the proxy should route sessions to xdebug-mcp by IDE key.
-
-#### Environment Variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `XDEBUG_PORT` | Yes | TCP callback port where `xdebug-mcp` listens for proxied DBGp sessions. Example: `9006`. This is **not** the proxy's port and must be unique per running `xdebug-mcp` instance. |
-| `XDEBUG_HOST` | No | Interface for the local callback listener. Defaults to `0.0.0.0`. |
-| `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
-| `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` / `proxystop`. Example: `9001`. |
-| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and distinct from every other running agent, for example `warp-mcp`, `claude-mcp`, or `codex-mcp`. |
-| `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), keep running in direct-listener mode if proxy registration fails, so `xdebug-mcp` still starts as a normal direct listener. When `false`, exit startup on registration failure. |
-
-Important constraints:
-- `XDEBUG_SOCKET_PATH` cannot be used together with DBGp proxy registration in the current implementation.
-- `XDEBUG_PORT` is the MCP callback listener port. PHP/Xdebug should still connect to the proxy's client-facing port. When multiple agents are active, each agent needs its own unique callback port.
-- Use a dedicated IDE key for each `xdebug-mcp` instance. Do not reuse the same IDE key as PhpStorm or another agent.
-- If you need separate registrations for multiple AI agents, do not place `xdebug-mcp` behind an MCP proxy or bundler. Register it directly in each agent's MCP configuration.
-
-#### MCP Configuration Examples
-
-**Installed package:**
-
-```json
-{
-  "mcpServers": {
-    "xdebug": {
-      "command": "xdebug-mcp",
-      "env": {
-        "XDEBUG_PORT": "9006",
-        "XDEBUG_HOST": "0.0.0.0",
-        "DBGP_PROXY_HOST": "127.0.0.1",
-        "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "warp-mcp",
-        "DBGP_PROXY_ALLOW_FALLBACK": "false",
-        "LOG_LEVEL": "info"
-      }
-    }
-  }
-}
-```
-
-**Run from a local source checkout:**
-
-```json
-{
-  "mcpServers": {
-    "xdebug": {
-      "command": "node",
-      "args": ["/absolute/path/to/xdebug-mcp/dist/index.js"],
-      "env": {
-        "XDEBUG_PORT": "9006",
-        "XDEBUG_HOST": "0.0.0.0",
-        "DBGP_PROXY_HOST": "127.0.0.1",
-        "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "warp-mcp",
-        "DBGP_PROXY_ALLOW_FALLBACK": "false",
-        "LOG_LEVEL": "info"
-      }
-    }
-  }
-}
-```
-
-Use the `node .../dist/index.js` form when running an unpublished local branch.
-The examples above show a Warp-style registration. For other agents, keep the same structure but swap in values such as `claude-mcp` with `9007` or `codex-mcp` with `9008`.
-
-#### Multiple AI Agents
-
-If you run more than one AI agent against the same DBGp proxy, each agent must start its own `xdebug-mcp` process directly and use unique registration values.
-
-Suggested values:
-- Warp: `DBGP_IDEKEY=warp-mcp`, `XDEBUG_PORT=9006`
-- Claude Code: `DBGP_IDEKEY=claude-mcp`, `XDEBUG_PORT=9007`
-- Codex: `DBGP_IDEKEY=codex-mcp`, `XDEBUG_PORT=9008`
-
-Keep PHP/Xdebug pointed at the proxy's client-facing port, then trigger the target agent using the matching IDE key.
-
-Do not install `xdebug-mcp` behind an MCP proxy or bundler in this setup. The uniqueness requirement applies to the actual `xdebug-mcp` process that registers with the DBGp proxy, so each agent needs its own direct registration.
-
-#### How Registration Works
-
-1. `xdebug-mcp` starts its local TCP listener on `XDEBUG_HOST:XDEBUG_PORT`.
-2. If `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` are present, it opens a control connection to the DBGp proxy.
-3. It sends:
-   - `proxyinit -p <XDEBUG_PORT> -k <DBGP_IDEKEY> -m 1`
-4. The proxy stores that registration and routes matching IDE-key sessions back to `xdebug-mcp`.
-5. On shutdown, `xdebug-mcp` sends:
-   - `proxystop -k <DBGP_IDEKEY>`
-
-Depending on your environment, this registration step can add a small startup delay, so give the MCP server a moment to finish booting before expecting the proxy to route sessions to it.
-
-#### PHP/Xdebug Side In Proxy Mode
-
-When using a DBGp proxy, PHP should point to the proxy, not directly to `xdebug-mcp`:
-
-```ini
-[xdebug]
-zend_extension=xdebug
-xdebug.mode=debug
-xdebug.start_with_request=trigger
-xdebug.client_host=127.0.0.1
-xdebug.client_port=9003
-```
-
-Then trigger the request with the IDE key registered for `xdebug-mcp`, for example:
-- `XDEBUG_TRIGGER=warp-mcp`
-- `XDEBUG_TRIGGER=claude-mcp`
-- `XDEBUG_TRIGGER=codex-mcp`
-
-You can use the same values with `XDEBUG_SESSION` if that matches your workflow.
-
-#### DBGp Proxy Binary / Download
-
-The official Xdebug DBGp proxy documentation, source, and download guidance are here:
-- https://xdebug.org/docs/dbgpProxy
-
-Use that page for installation details and the current recommended binary/source distribution method for the proxy.
+See the [DBGp Proxy Registration Guide](./docs/_guides/dbgp-proxy-registration.md) for the full setup, multi-agent examples, and PHP/Xdebug proxy configuration.
 
 ## PHP/Xdebug Configuration
 
@@ -513,13 +366,9 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode). In DBGp proxy mode, set this to a separate callback port such as `9006`, `9007`, or `9008`, not the proxy's client-facing port, and keep it unique per running `xdebug-mcp` instance |
+| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode) |
 | `XDEBUG_HOST` | `0.0.0.0` | Host to bind (TCP mode) |
 | `XDEBUG_SOCKET_PATH` | - | Unix domain socket path (e.g., `/tmp/xdebug.sock`). When set, uses Unix socket instead of TCP |
-| `DBGP_PROXY_HOST` | - | DBGp proxy host for optional IDE registration |
-| `DBGP_PROXY_PORT` | - | DBGp proxy port for optional IDE registration (typically `9001`) |
-| `DBGP_IDEKEY` | - | IDE key to register with the DBGp proxy. Keep it unique per running `xdebug-mcp` instance or agent |
-| `DBGP_PROXY_ALLOW_FALLBACK` | `true` | Continue in direct-listener mode when proxy registration fails |
 | `COMMAND_TIMEOUT` | `30000` | Command timeout in milliseconds |
 | `PATH_MAPPINGS` | - | JSON object mapping container to host paths |
 | `MAX_DEPTH` | `3` | Max depth for variable inspection |
@@ -564,7 +413,6 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 **Connection Options:**
 - **TCP (Default):** `xdebug.client_host=127.0.0.1` + `XDEBUG_PORT=9003`
 - **Unix Socket:** `xdebug.client_host=unix:///tmp/xdebug.sock` + `XDEBUG_SOCKET_PATH=/tmp/xdebug.sock`
-- **DBGp Proxy:** Keep xdebug-mcp listening on TCP, set `XDEBUG_PORT` to a unique callback port per agent such as `9006`, `9007`, or `9008`, and set `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` so the server registers itself with your proxy on startup
 
 ## Troubleshooting
 
@@ -594,26 +442,6 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 3. **Socket path in php.ini:**
    - Correct: `xdebug.client_host=unix:///tmp/xdebug.sock`
    - Wrong: `xdebug.client_host=unix:/tmp/xdebug.sock` (missing one `/`)
-
-### DBGp proxy issues
-
-1. **Server starts but never registers with the proxy**
-   - Set `LOG_LEVEL=debug`
-   - Verify `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` are all present
-2. **Proxy mode with Unix sockets**
-   - Remove `XDEBUG_SOCKET_PATH`
-   - DBGp proxy registration requires TCP listener mode
-3. **Proxy registration failure should stop startup**
-   - Set `DBGP_PROXY_ALLOW_FALLBACK=false`
-4. **Proxy cannot route back to xdebug-mcp**
-   - Do not set `XDEBUG_PORT` to the proxy's client-facing port
-   - Use a separate callback port such as `9006`
-   - Make sure the MCP server's `XDEBUG_PORT` is reachable from the proxy
-   - Remember that the proxy uses the registration connection's source address plus the `-p` port
-5. **Multiple agents interfere with each other**
-   - Do not reuse the same `DBGP_IDEKEY` across Warp, Claude Code, Codex, PhpStorm, or any other client
-   - Do not reuse the same `XDEBUG_PORT` across multiple running `xdebug-mcp` instances
-   - Register `xdebug-mcp` directly in each agent instead of placing it behind an MCP proxy or bundler when you need unique per-agent DBGp registrations
 
 ### Breakpoints not hitting
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you already use a DBGp proxy, xdebug-mcp can register itself on startup in th
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "mcp",
+        "DBGP_IDEKEY": "warp-mcp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info"
       }
@@ -132,6 +132,9 @@ Notes:
 - On shutdown, xdebug-mcp sends `proxystop -k <idekey>`.
 - If `DBGP_PROXY_ALLOW_FALLBACK=false`, startup fails when proxy registration fails.
 - If `DBGP_PROXY_ALLOW_FALLBACK=true`, the server logs the error and continues in direct-listener mode.
+- If you run multiple AI agents at the same time, each `xdebug-mcp` instance must use a unique `DBGP_IDEKEY` and a unique `XDEBUG_PORT`.
+- Example values: Warp = `warp-mcp` on `9006`, Claude Code = `claude-mcp` on `9007`, Codex = `codex-mcp` on `9008`.
+- Do not install `xdebug-mcp` behind an MCP proxy or bundler when you need unique per-agent registrations. Register `xdebug-mcp` directly in each agent instead.
 
 ### DBGp Proxy Configuration Guide
 
@@ -141,17 +144,18 @@ Use this mode when PHP should connect to a DBGp proxy, and the proxy should rout
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `XDEBUG_PORT` | Yes | TCP callback port where `xdebug-mcp` listens for proxied DBGp sessions. Example: `9006`. This is **not** the proxy's port. |
+| `XDEBUG_PORT` | Yes | TCP callback port where `xdebug-mcp` listens for proxied DBGp sessions. Example: `9006`. This is **not** the proxy's port and must be unique per running `xdebug-mcp` instance. |
 | `XDEBUG_HOST` | No | Interface for the local callback listener. Defaults to `0.0.0.0`. |
 | `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
 | `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` / `proxystop`. Example: `9001`. |
-| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm, for example `mcp`. |
+| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and distinct from every other running agent, for example `warp-mcp`, `claude-mcp`, or `codex-mcp`. |
 | `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), keep running in direct-listener mode if proxy registration fails. When `false`, exit startup on registration failure. |
 
 Important constraints:
 - `XDEBUG_SOCKET_PATH` cannot be used together with DBGp proxy registration in the current implementation.
-- `XDEBUG_PORT` is the MCP callback listener port. PHP/Xdebug should still connect to the proxy's client-facing port.
-- Use a dedicated IDE key for xdebug-mcp. Do not reuse the same IDE key as PhpStorm.
+- `XDEBUG_PORT` is the MCP callback listener port. PHP/Xdebug should still connect to the proxy's client-facing port. When multiple agents are active, each agent needs its own unique callback port.
+- Use a dedicated IDE key for each `xdebug-mcp` instance. Do not reuse the same IDE key as PhpStorm or another agent.
+- If you need separate registrations for multiple AI agents, do not place `xdebug-mcp` behind an MCP proxy or bundler. Register it directly in each agent's MCP configuration.
 
 #### MCP Configuration Examples
 
@@ -167,7 +171,7 @@ Important constraints:
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "mcp",
+        "DBGP_IDEKEY": "warp-mcp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info"
       }
@@ -189,7 +193,7 @@ Important constraints:
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "mcp",
+        "DBGP_IDEKEY": "warp-mcp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info"
       }
@@ -199,6 +203,20 @@ Important constraints:
 ```
 
 Use the `node .../dist/index.js` form when running an unpublished local branch.
+The examples above show a Warp-style registration. For other agents, keep the same structure but swap in values such as `claude-mcp` with `9007` or `codex-mcp` with `9008`.
+
+#### Multiple AI Agents
+
+If you run more than one AI agent against the same DBGp proxy, each agent must start its own `xdebug-mcp` process directly and use unique registration values.
+
+Suggested values:
+- Warp: `DBGP_IDEKEY=warp-mcp`, `XDEBUG_PORT=9006`
+- Claude Code: `DBGP_IDEKEY=claude-mcp`, `XDEBUG_PORT=9007`
+- Codex: `DBGP_IDEKEY=codex-mcp`, `XDEBUG_PORT=9008`
+
+Keep PHP/Xdebug pointed at the proxy's client-facing port, then trigger the target agent using the matching IDE key.
+
+Do not install `xdebug-mcp` behind an MCP proxy or bundler in this setup. The uniqueness requirement applies to the actual `xdebug-mcp` process that registers with the DBGp proxy, so each agent needs its own direct registration.
 
 #### How Registration Works
 
@@ -224,8 +242,11 @@ xdebug.client_port=9003
 ```
 
 Then trigger the request with the IDE key registered for `xdebug-mcp`, for example:
-- `XDEBUG_TRIGGER=mcp`
-- `XDEBUG_SESSION=mcp`
+- `XDEBUG_TRIGGER=warp-mcp`
+- `XDEBUG_TRIGGER=claude-mcp`
+- `XDEBUG_TRIGGER=codex-mcp`
+
+You can use the same values with `XDEBUG_SESSION` if that matches your workflow.
 
 #### DBGp Proxy Binary / Download
 
@@ -488,12 +509,12 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode). In DBGp proxy mode, set this to a separate callback port such as `9006`, not the proxy's client-facing port |
+| `XDEBUG_PORT` | `9003` | Port to listen for Xdebug connections (TCP mode). In DBGp proxy mode, set this to a separate callback port such as `9006`, `9007`, or `9008`, not the proxy's client-facing port, and keep it unique per running `xdebug-mcp` instance |
 | `XDEBUG_HOST` | `0.0.0.0` | Host to bind (TCP mode) |
 | `XDEBUG_SOCKET_PATH` | - | Unix domain socket path (e.g., `/tmp/xdebug.sock`). When set, uses Unix socket instead of TCP |
 | `DBGP_PROXY_HOST` | - | DBGp proxy host for optional IDE registration |
 | `DBGP_PROXY_PORT` | - | DBGp proxy port for optional IDE registration (typically `9001`) |
-| `DBGP_IDEKEY` | - | IDE key to register with the DBGp proxy |
+| `DBGP_IDEKEY` | - | IDE key to register with the DBGp proxy. Keep it unique per running `xdebug-mcp` instance or agent |
 | `DBGP_PROXY_ALLOW_FALLBACK` | `true` | Continue in direct-listener mode when proxy registration fails |
 | `COMMAND_TIMEOUT` | `30000` | Command timeout in milliseconds |
 | `PATH_MAPPINGS` | - | JSON object mapping container to host paths |
@@ -539,7 +560,7 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
 **Connection Options:**
 - **TCP (Default):** `xdebug.client_host=127.0.0.1` + `XDEBUG_PORT=9003`
 - **Unix Socket:** `xdebug.client_host=unix:///tmp/xdebug.sock` + `XDEBUG_SOCKET_PATH=/tmp/xdebug.sock`
-- **DBGp Proxy:** Keep xdebug-mcp listening on TCP, set `XDEBUG_PORT` to a separate callback port such as `9006`, and set `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` so the server registers itself with your proxy on startup
+- **DBGp Proxy:** Keep xdebug-mcp listening on TCP, set `XDEBUG_PORT` to a unique callback port per agent such as `9006`, `9007`, or `9008`, and set `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` so the server registers itself with your proxy on startup
 
 ## Troubleshooting
 
@@ -585,6 +606,10 @@ Use capture_request_context to see $_GET, $_POST, $_SESSION, cookies, and header
    - Use a separate callback port such as `9006`
    - Make sure the MCP server's `XDEBUG_PORT` is reachable from the proxy
    - Remember that the proxy uses the registration connection's source address plus the `-p` port
+5. **Multiple agents interfere with each other**
+   - Do not reuse the same `DBGP_IDEKEY` across Warp, Claude Code, Codex, PhpStorm, or any other client
+   - Do not reuse the same `XDEBUG_PORT` across multiple running `xdebug-mcp` instances
+   - Register `xdebug-mcp` directly in each agent instead of placing it behind an MCP proxy or bundler when you need unique per-agent DBGp registrations
 
 ### Breakpoints not hitting
 

--- a/docs/_guides/dbgp-proxy-registration.md
+++ b/docs/_guides/dbgp-proxy-registration.md
@@ -27,7 +27,7 @@ If you just want a single local debugging listener, stay with the default direct
 | `XDEBUG_HOST` | No | Interface for the local callback listener. Defaults to `0.0.0.0`. |
 | `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
 | `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` and `proxystop`. Example: `9001`. |
-| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and every other running agent, for example `warp-mcp`, `claude-mcp`, or `codex-mcp`. |
+| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and every other running agent, for example `xdebug-warp`, `xdebug-claude`, or `xdebug-codex`. |
 | `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), continue in direct-listener mode if proxy registration fails. When `false`, fail startup instead. |
 
 Important constraints:
@@ -54,7 +54,7 @@ Start from [`mcp-config.proxy.example.json`](../../mcp-config.proxy.example.json
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "warp-mcp",
+        "DBGP_IDEKEY": "xdebug-warp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info"
       }
@@ -76,7 +76,7 @@ Start from [`mcp-config.proxy.example.json`](../../mcp-config.proxy.example.json
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "warp-mcp",
+        "DBGP_IDEKEY": "xdebug-warp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info"
       }
@@ -91,9 +91,9 @@ If you run more than one AI agent against the same DBGp proxy, each agent must s
 
 Suggested values:
 
-- Warp: `DBGP_IDEKEY=warp-mcp`, `XDEBUG_PORT=9006`
-- Claude Code: `DBGP_IDEKEY=claude-mcp`, `XDEBUG_PORT=9007`
-- Codex: `DBGP_IDEKEY=codex-mcp`, `XDEBUG_PORT=9008`
+- Warp: `DBGP_IDEKEY=xdebug-warp`, `XDEBUG_PORT=9006`
+- Claude Code: `DBGP_IDEKEY=xdebug-claude`, `XDEBUG_PORT=9007`
+- Codex: `DBGP_IDEKEY=xdebug-codex`, `XDEBUG_PORT=9008`
 
 Keep PHP/Xdebug pointed at the proxy's client-facing port, then trigger the target agent using the matching IDE key.
 
@@ -122,9 +122,9 @@ xdebug.client_port=9003
 
 Then trigger the request with the IDE key registered for `xdebug-mcp`, for example:
 
-- `XDEBUG_TRIGGER=warp-mcp`
-- `XDEBUG_TRIGGER=claude-mcp`
-- `XDEBUG_TRIGGER=codex-mcp`
+- `XDEBUG_TRIGGER=xdebug-warp`
+- `XDEBUG_TRIGGER=xdebug-claude`
+- `XDEBUG_TRIGGER=xdebug-codex`
 
 You can use the same values with `XDEBUG_SESSION` if that matches your workflow.
 

--- a/docs/_guides/dbgp-proxy-registration.md
+++ b/docs/_guides/dbgp-proxy-registration.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: DBGp Proxy Registration Guide | Xdebug MCP
+description: Configure xdebug-mcp with a DBGp proxy, unique IDE keys, separate callback ports, and multi-agent routing.
+permalink: /:collection/:name/
+---
+
+# DBGp Proxy Registration Guide
+
+Use this mode when PHP should connect to a DBGp proxy, and the proxy should route matching IDE keys back to `xdebug-mcp`.
+
+## When to Use This
+
+Choose DBGp proxy registration when:
+
+- you already run a shared DBGp proxy for PhpStorm or another IDE
+- you want multiple AI agents to coexist without fighting over one Xdebug port
+- PHP should keep connecting to the proxy, while each `xdebug-mcp` instance listens on its own callback port
+
+If you just want a single local debugging listener, stay with the default direct TCP setup in [`mcp-config.example.json`](../../mcp-config.example.json).
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `XDEBUG_PORT` | Yes | TCP callback port where `xdebug-mcp` listens for proxied DBGp sessions. Example: `9006`. This is **not** the proxy's client-facing port and must be unique per running `xdebug-mcp` instance. |
+| `XDEBUG_HOST` | No | Interface for the local callback listener. Defaults to `0.0.0.0`. |
+| `DBGP_PROXY_HOST` | Yes | Hostname or IP address of the DBGp proxy. Example: `127.0.0.1`. |
+| `DBGP_PROXY_PORT` | Yes | Port where the DBGp proxy accepts `proxyinit` and `proxystop`. Example: `9001`. |
+| `DBGP_IDEKEY` | Yes | IDE key that the proxy should route to this MCP server. Use a value distinct from PhpStorm and every other running agent, for example `warp-mcp`, `claude-mcp`, or `codex-mcp`. |
+| `DBGP_PROXY_ALLOW_FALLBACK` | No | When `true` (default), continue in direct-listener mode if proxy registration fails. When `false`, fail startup instead. |
+
+Important constraints:
+
+- `XDEBUG_SOCKET_PATH` cannot be used together with DBGp proxy registration.
+- `XDEBUG_PORT` is the callback listener for `xdebug-mcp`. PHP/Xdebug should still connect to the proxy's client-facing port.
+- Use a dedicated IDE key for each `xdebug-mcp` instance. Do not reuse the same IDE key as PhpStorm or another agent.
+- Keep `DBGP_IDEKEY` simple: no spaces, quotes, or backslashes. The reference `dbgpProxy` implementation does not parse escaped argument values.
+- If you need separate registrations for multiple AI agents, do not place `xdebug-mcp` behind an MCP proxy or bundler. Register it directly in each agent's MCP configuration.
+
+## MCP Configuration Examples
+
+Start from [`mcp-config.proxy.example.json`](../../mcp-config.proxy.example.json) if you want a copyable proxy-mode example.
+
+**Installed package:**
+
+```json
+{
+  "mcpServers": {
+    "xdebug": {
+      "command": "xdebug-mcp",
+      "env": {
+        "XDEBUG_PORT": "9006",
+        "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "warp-mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+**Using `npx`:**
+
+```json
+{
+  "mcpServers": {
+    "xdebug": {
+      "command": "npx",
+      "args": ["-y", "xdebug-mcp"],
+      "env": {
+        "XDEBUG_PORT": "9006",
+        "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "warp-mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+## Multiple AI Agents
+
+If you run more than one AI agent against the same DBGp proxy, each agent must start its own `xdebug-mcp` process directly and use unique registration values.
+
+Suggested values:
+
+- Warp: `DBGP_IDEKEY=warp-mcp`, `XDEBUG_PORT=9006`
+- Claude Code: `DBGP_IDEKEY=claude-mcp`, `XDEBUG_PORT=9007`
+- Codex: `DBGP_IDEKEY=codex-mcp`, `XDEBUG_PORT=9008`
+
+Keep PHP/Xdebug pointed at the proxy's client-facing port, then trigger the target agent using the matching IDE key.
+
+## How Registration Works
+
+1. `xdebug-mcp` starts its local TCP listener on `XDEBUG_HOST:XDEBUG_PORT`.
+2. If `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, and `DBGP_IDEKEY` are present, it opens a control connection to the DBGp proxy.
+3. It sends `proxyinit -p <XDEBUG_PORT> -k <DBGP_IDEKEY> -m 1`.
+4. The proxy stores that registration and routes matching IDE-key sessions back to `xdebug-mcp`.
+5. On shutdown, `xdebug-mcp` sends `proxystop -k <DBGP_IDEKEY>`.
+
+Depending on your environment, registration can add a small startup delay, so give the MCP server a moment to finish booting before expecting the proxy to route sessions to it.
+
+## PHP/Xdebug Side in Proxy Mode
+
+When using a DBGp proxy, PHP should point to the proxy, not directly to `xdebug-mcp`:
+
+```ini
+[xdebug]
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.start_with_request=trigger
+xdebug.client_host=127.0.0.1
+xdebug.client_port=9003
+```
+
+Then trigger the request with the IDE key registered for `xdebug-mcp`, for example:
+
+- `XDEBUG_TRIGGER=warp-mcp`
+- `XDEBUG_TRIGGER=claude-mcp`
+- `XDEBUG_TRIGGER=codex-mcp`
+
+You can use the same values with `XDEBUG_SESSION` if that matches your workflow.
+
+## DBGp Proxy Binary / Download
+
+The official Xdebug DBGp proxy documentation, source, and download guidance are here:
+
+- https://xdebug.org/docs/dbgpProxy
+
+Use that page for installation details and the current recommended binary or source distribution method for the proxy.

--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -32,7 +32,7 @@ Optional DBGp proxy registration:
 ```bash
 DBGP_PROXY_HOST=127.0.0.1
 DBGP_PROXY_PORT=9001
-DBGP_IDEKEY=claude-mcp
+DBGP_IDEKEY=xdebug-claude
 DBGP_PROXY_ALLOW_FALLBACK=true
 ```
 

--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -27,6 +27,19 @@ XDEBUG_SOCKET_PATH=/tmp/xdebug.sock  # Socket path
 DEBUG=xdebug-mcp              # Enable debug output
 ```
 
+Optional DBGp proxy registration:
+
+```bash
+DBGP_PROXY_HOST=127.0.0.1
+DBGP_PROXY_PORT=9001
+DBGP_IDEKEY=claude-mcp
+DBGP_PROXY_ALLOW_FALLBACK=true
+```
+
+`DBGP_IDEKEY` should stay simple ASCII without spaces, quotes, or backslashes so it remains compatible with the reference `dbgpProxy` parser.
+
+For the full proxy-mode workflow, see the [DBGp Proxy Registration Guide](/guides/dbgp-proxy-registration/).
+
 ### Usage Examples
 
 **TCP Mode (Default):**

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ claude mcp add xdebug-mcp npx xdebug-mcp
 ### Getting Started
 - **[Agent Integration Guide](guides/agent-integration/)** ⭐ — Setup for Claude, Cursor, Cline, VS Code, Copilot, Windsurf, PhpStorm
 - **[Installation & Setup](guides/getting-started/)** — Prerequisites and installation
+- **[DBGp Proxy Registration Guide](guides/dbgp-proxy-registration/)** — Configure proxy routing, IDE keys, and multi-agent callback ports
 - **[Debugging Guide](guides/debugging-guide/)** — Learn debugging workflows
 
 ### Configuration & Reference

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -4,11 +4,11 @@
       "command": "node",
       "args": ["/home/power/Projects/xdebug-mcp/dist/index.js"],
       "env": {
-        "XDEBUG_PORT": "9006",
+        "XDEBUG_PORT": "9007",
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "mcp",
+        "DBGP_IDEKEY": "claude-mcp",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info",
         "PATH_MAPPINGS": "{\"/var/www/html\": \"/home/power/projects/myapp\"}"

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -4,8 +4,12 @@
       "command": "node",
       "args": ["/home/power/Projects/xdebug-mcp/dist/index.js"],
       "env": {
-        "XDEBUG_PORT": "9003",
+        "XDEBUG_PORT": "9006",
         "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info",
         "PATH_MAPPINGS": "{\"/var/www/html\": \"/home/power/projects/myapp\"}"
       }

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "xdebug": {
-      "command": "npx",
-      "args": ["-y", "xdebug-mcp"],
+      "command": "node",
+      "args": ["/home/power/Projects/xdebug-mcp/dist/index.js"],
       "env": {
         "XDEBUG_PORT": "9003",
         "XDEBUG_HOST": "0.0.0.0",

--- a/mcp-config.proxy.example.json
+++ b/mcp-config.proxy.example.json
@@ -8,7 +8,7 @@
         "XDEBUG_HOST": "0.0.0.0",
         "DBGP_PROXY_HOST": "127.0.0.1",
         "DBGP_PROXY_PORT": "9001",
-        "DBGP_IDEKEY": "claude-mcp",
+        "DBGP_IDEKEY": "xdebug-claude",
         "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info",
         "PATH_MAPPINGS": "{\"/var/www/html\": \"/home/power/projects/myapp\"}"

--- a/mcp-config.proxy.example.json
+++ b/mcp-config.proxy.example.json
@@ -4,8 +4,12 @@
       "command": "npx",
       "args": ["-y", "xdebug-mcp"],
       "env": {
-        "XDEBUG_PORT": "9003",
+        "XDEBUG_PORT": "9007",
         "XDEBUG_HOST": "0.0.0.0",
+        "DBGP_PROXY_HOST": "127.0.0.1",
+        "DBGP_PROXY_PORT": "9001",
+        "DBGP_IDEKEY": "claude-mcp",
+        "DBGP_PROXY_ALLOW_FALLBACK": "false",
         "LOG_LEVEL": "info",
         "PATH_MAPPINGS": "{\"/var/www/html\": \"/home/power/projects/myapp\"}"
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,11 +7,15 @@ import { logger } from './utils/logger.js';
 
 const PathMappingsSchema = z.record(z.string(), z.string());
 const LogLevelSchema = z.enum(['debug', 'info', 'warn', 'error']);
+const ProxyIdeKeySchema = z.string().min(1).refine(
+  (value) => !/[\0\s"\\]/.test(value),
+  'DBGP_IDEKEY must not contain spaces, quotes, backslashes, or null bytes because the reference DBGp proxy does not parse escaped arguments.'
+);
 
 const ProxyConfigSchema = z.object({
   host: z.string().min(1),
   port: z.number().int().positive(),
-  ideKey: z.string().min(1),
+  ideKey: ProxyIdeKeySchema,
   allowFallback: z.boolean().default(true),
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,12 +5,20 @@
 import { z } from 'zod';
 import { LogLevel, logger } from './utils/logger.js';
 
+const ProxyConfigSchema = z.object({
+  host: z.string().min(1),
+  port: z.number().int().positive(),
+  ideKey: z.string().min(1),
+  allowFallback: z.boolean().default(true),
+});
+
 const ConfigSchema = z.object({
   // DBGp server settings
   dbgpPort: z.number().int().positive().default(9003),
   dbgpHost: z.string().default('0.0.0.0'),
   dbgpSocketPath: z.string().optional(),
   commandTimeout: z.number().int().positive().default(30000),
+  proxy: ProxyConfigSchema.optional(),
 
   // Path mappings for Docker
   pathMappings: z.record(z.string(), z.string()).optional(),
@@ -40,6 +48,31 @@ export function loadConfig(): Config {
   // Add socket path if provided
   if (process.env.XDEBUG_SOCKET_PATH) {
     rawConfig.dbgpSocketPath = process.env.XDEBUG_SOCKET_PATH;
+  }
+
+  const proxyHost = process.env.DBGP_PROXY_HOST;
+  const proxyPort = process.env.DBGP_PROXY_PORT;
+  const proxyIdeKey = process.env.DBGP_IDEKEY;
+
+  if (proxyHost || proxyPort || proxyIdeKey) {
+    if (!proxyHost || !proxyPort || !proxyIdeKey) {
+      throw new Error(
+        'DBGp proxy configuration is incomplete. Set DBGP_PROXY_HOST, DBGP_PROXY_PORT, and DBGP_IDEKEY together.'
+      );
+    }
+
+    if (process.env.XDEBUG_SOCKET_PATH) {
+      throw new Error(
+        'DBGp proxy registration requires TCP listener mode. Remove XDEBUG_SOCKET_PATH when using DBGP proxy registration.'
+      );
+    }
+
+    rawConfig.proxy = {
+      host: proxyHost,
+      port: parseInt(proxyPort, 10),
+      ideKey: proxyIdeKey,
+      allowFallback: process.env.DBGP_PROXY_ALLOW_FALLBACK !== 'false',
+    };
   }
 
   // Parse path mappings from JSON if provided

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,10 @@
  */
 
 import { z } from 'zod';
-import { LogLevel, logger } from './utils/logger.js';
+import { logger } from './utils/logger.js';
+
+const PathMappingsSchema = z.record(z.string(), z.string());
+const LogLevelSchema = z.enum(['debug', 'info', 'warn', 'error']);
 
 const ProxyConfigSchema = z.object({
   host: z.string().min(1),
@@ -29,20 +32,26 @@ const ConfigSchema = z.object({
   maxData: z.number().int().positive().default(2048),
 
   // Logging
-  logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+  logLevel: LogLevelSchema.default('info'),
 });
 
+/**
+ * Runtime configuration resolved from environment variables and validated with Zod.
+ */
 export type Config = z.infer<typeof ConfigSchema>;
 
+/**
+ * Load the process configuration and fail fast when the environment is inconsistent.
+ */
 export function loadConfig(): Config {
-  const rawConfig: Record<string, unknown> = {
+  const rawConfig: z.input<typeof ConfigSchema> = {
     dbgpPort: parseInt(process.env.XDEBUG_PORT || '9003', 10),
     dbgpHost: process.env.XDEBUG_HOST || '0.0.0.0',
     commandTimeout: parseInt(process.env.COMMAND_TIMEOUT || '30000', 10),
     maxDepth: parseInt(process.env.MAX_DEPTH || '3', 10),
     maxChildren: parseInt(process.env.MAX_CHILDREN || '128', 10),
     maxData: parseInt(process.env.MAX_DATA || '2048', 10),
-    logLevel: process.env.LOG_LEVEL || 'info',
+    logLevel: LogLevelSchema.parse(process.env.LOG_LEVEL || 'info'),
   };
 
   // Add socket path if provided
@@ -55,30 +64,32 @@ export function loadConfig(): Config {
   const proxyIdeKey = process.env.DBGP_IDEKEY;
 
   if (proxyHost || proxyPort || proxyIdeKey) {
+    // Require the full proxy tuple together so startup never lands in a half-configured mode.
     if (!proxyHost || !proxyPort || !proxyIdeKey) {
       throw new Error(
         'DBGp proxy configuration is incomplete. Set DBGP_PROXY_HOST, DBGP_PROXY_PORT, and DBGP_IDEKEY together.'
       );
     }
 
+    // Proxy registration needs a reachable TCP listener, so Unix socket mode must stay disabled here.
     if (process.env.XDEBUG_SOCKET_PATH) {
       throw new Error(
         'DBGp proxy registration requires TCP listener mode. Remove XDEBUG_SOCKET_PATH when using DBGP proxy registration.'
       );
     }
 
-    rawConfig.proxy = {
+    rawConfig.proxy = ProxyConfigSchema.parse({
       host: proxyHost,
       port: parseInt(proxyPort, 10),
       ideKey: proxyIdeKey,
       allowFallback: process.env.DBGP_PROXY_ALLOW_FALLBACK !== 'false',
-    };
+    });
   }
 
   // Parse path mappings from JSON if provided
   if (process.env.PATH_MAPPINGS) {
     try {
-      rawConfig.pathMappings = JSON.parse(process.env.PATH_MAPPINGS);
+      rawConfig.pathMappings = PathMappingsSchema.parse(JSON.parse(process.env.PATH_MAPPINGS));
     } catch {
       logger.warn('Failed to parse PATH_MAPPINGS environment variable');
     }
@@ -87,11 +98,14 @@ export function loadConfig(): Config {
   const config = ConfigSchema.parse(rawConfig);
 
   // Apply log level
-  logger.setLevel(config.logLevel as LogLevel);
+  logger.setLevel(config.logLevel);
 
   return config;
 }
 
+/**
+ * Return the schema defaults without reading from the process environment.
+ */
 export function getDefaultConfig(): Config {
   return ConfigSchema.parse({});
 }

--- a/src/dbgp/proxy.ts
+++ b/src/dbgp/proxy.ts
@@ -10,7 +10,6 @@ export interface DbgpProxyConfig {
   host: string;
   port: number;
   ideKey: string;
-  allowFallback: boolean;
 }
 
 export interface ProxyRegistration {
@@ -94,6 +93,7 @@ export class DbgpProxyClient {
 
   private async sendProxyCommand(command: string): Promise<Record<string, unknown>> {
     return new Promise((resolve, reject) => {
+      const commandName = command.split(' ', 1)[0] || 'DBGp proxy command';
       const socket = net.createConnection(
         {
           host: this.config.host,
@@ -116,10 +116,27 @@ export class DbgpProxyClient {
         handler();
       };
 
+      const resolveResponse = (destroySocket: boolean) => {
+        finish(() => {
+          try {
+            const parsedResponse = this.parseResponse(response);
+            if (destroySocket) {
+              socket.destroy();
+            }
+            resolve(parsedResponse);
+          } catch (error) {
+            if (destroySocket) {
+              socket.destroy();
+            }
+            reject(error);
+          }
+        });
+      };
+
       const timeout = setTimeout(() => {
         finish(() => {
           socket.destroy();
-          reject(new Error(`DBGp proxy command timed out: ${command}`));
+          reject(new Error(`${commandName} timed out waiting for a DBGp proxy response`));
         });
       }, 10000);
 
@@ -127,6 +144,10 @@ export class DbgpProxyClient {
 
       socket.on('data', (chunk) => {
         response += chunk;
+        if (!response.includes('\0')) {
+          return;
+        }
+        resolveResponse(true);
       });
 
       socket.on('error', (error) => {
@@ -136,13 +157,7 @@ export class DbgpProxyClient {
       });
 
       socket.on('end', () => {
-        finish(() => {
-          try {
-            resolve(this.parseResponse(response));
-          } catch (error) {
-            reject(error);
-          }
-        });
+        resolveResponse(false);
       });
 
       socket.on('close', (hadError) => {
@@ -150,13 +165,7 @@ export class DbgpProxyClient {
           return;
         }
 
-        finish(() => {
-          try {
-            resolve(this.parseResponse(response));
-          } catch (error) {
-            reject(error);
-          }
-        });
+        resolveResponse(false);
       });
     });
   }
@@ -171,12 +180,23 @@ export class DbgpProxyClient {
   }
 
   private getResponseNode(response: Record<string, unknown>, key: string): ProxyXmlResponse {
-    const node = response[key];
-    if (!node || Array.isArray(node) || typeof node !== 'object') {
-      throw new Error(`Unexpected DBGp proxy response: missing <${key}> root element`);
+    const directNode = response[key];
+    if (directNode && !Array.isArray(directNode) && typeof directNode === 'object') {
+      return directNode as ProxyXmlResponse;
     }
 
-    return node as ProxyXmlResponse;
+    for (const value of Object.values(response)) {
+      if (!value || Array.isArray(value) || typeof value !== 'object') {
+        continue;
+      }
+
+      const nestedNode = (value as Record<string, unknown>)[key];
+      if (nestedNode && !Array.isArray(nestedNode) && typeof nestedNode === 'object') {
+        return nestedNode as ProxyXmlResponse;
+      }
+    }
+
+    throw new Error(`Unexpected DBGp proxy response: missing <${key}> root element`);
   }
 
   private getErrorMessage(response: ProxyXmlResponse, fallbackMessage: string): string {
@@ -197,8 +217,11 @@ export class DbgpProxyClient {
   }
 
   private escapeArg(value: string): string {
-    if (/[\\s"\\\\]/.test(value)) {
-      return `"${value.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\"')}"`;
+    if (value.includes('\0')) {
+      throw new Error('DBGp proxy arguments cannot contain null bytes');
+    }
+    if (/[\s"\\]/.test(value)) {
+      return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
     }
 
     return value;

--- a/src/dbgp/proxy.ts
+++ b/src/dbgp/proxy.ts
@@ -6,17 +6,25 @@
 import * as net from 'net';
 import { XMLParser } from 'fast-xml-parser';
 
+/**
+ * Connection settings for the external DBGp proxy.
+ */
 export interface DbgpProxyConfig {
   host: string;
   port: number;
   ideKey: string;
 }
 
+/**
+ * Successful proxy registration details returned by the proxy server.
+ */
 export interface ProxyRegistration {
   ideKey: string;
   address?: string;
   port?: number;
 }
+
+type ProxyCommandName = 'proxyinit' | 'proxystop';
 
 interface ProxyXmlResponse {
   success?: string;
@@ -30,6 +38,11 @@ interface ProxyXmlResponse {
   };
 }
 
+type ProxyResponseEnvelope = Partial<Record<ProxyCommandName, ProxyXmlResponse>> & Record<string, unknown>;
+
+/**
+ * Register and unregister this MCP server against a DBGp proxy.
+ */
 export class DbgpProxyClient {
   private readonly xmlParser: XMLParser;
   private registration: ProxyRegistration | null = null;
@@ -44,14 +57,23 @@ export class DbgpProxyClient {
     });
   }
 
+  /**
+   * Whether the client currently has an active proxy registration.
+   */
   get isRegistered(): boolean {
     return this.registration !== null;
   }
 
+  /**
+   * Return the active registration details when registration succeeded.
+   */
   get currentRegistration(): ProxyRegistration | null {
     return this.registration;
   }
 
+  /**
+   * Register the current IDE key with the proxy so incoming Xdebug sessions are routed here.
+   */
   async register(listenPort: number, supportsMultipleSessions: boolean): Promise<ProxyRegistration> {
     const multipleSessionsFlag = supportsMultipleSessions ? '1' : '0';
     const response = await this.sendProxyCommand(
@@ -67,12 +89,15 @@ export class DbgpProxyClient {
     this.registration = {
       ideKey: proxyInit['@_idekey'] || this.config.ideKey,
       address: proxyInit['@_address'],
-      port: proxyInit['@_port'] ? parseInt(proxyInit['@_port'], 10) : undefined,
+      port: this.parseOptionalPort(proxyInit['@_port']),
     };
 
     return this.registration;
   }
 
+  /**
+   * Remove the current registration from the proxy before shutting down the local listener.
+   */
   async unregister(): Promise<void> {
     if (!this.registration) {
       return;
@@ -91,7 +116,10 @@ export class DbgpProxyClient {
     this.registration = null;
   }
 
-  private async sendProxyCommand(command: string): Promise<Record<string, unknown>> {
+  /**
+   * Send a single proxy command and parse the XML payload returned by the proxy server.
+   */
+  private async sendProxyCommand(command: string): Promise<ProxyResponseEnvelope> {
     return new Promise((resolve, reject) => {
       const commandName = command.split(' ', 1)[0] || 'DBGp proxy command';
       const socket = net.createConnection(
@@ -156,6 +184,7 @@ export class DbgpProxyClient {
         });
       });
 
+      // Some proxies close immediately after the NULL-terminated payload, so accept either event.
       socket.on('end', () => {
         resolveResponse(false);
       });
@@ -170,28 +199,34 @@ export class DbgpProxyClient {
     });
   }
 
-  private parseResponse(response: string): Record<string, unknown> {
+  /**
+   * Parse the proxy XML payload into a typed envelope once transport framing is removed.
+   */
+  private parseResponse(response: string): ProxyResponseEnvelope {
     const payload = response.replace(/\0/g, '').trim();
     if (!payload) {
       throw new Error('DBGp proxy returned an empty response');
     }
 
-    return this.xmlParser.parse(payload) as Record<string, unknown>;
+    return this.xmlParser.parse(payload) as ProxyResponseEnvelope;
   }
 
-  private getResponseNode(response: Record<string, unknown>, key: string): ProxyXmlResponse {
+  /**
+   * Extract the command response node even when proxies wrap it inside an outer document element.
+   */
+  private getResponseNode(response: ProxyResponseEnvelope, key: ProxyCommandName): ProxyXmlResponse {
     const directNode = response[key];
-    if (directNode && !Array.isArray(directNode) && typeof directNode === 'object') {
+    if (this.isObjectRecord(directNode)) {
       return directNode as ProxyXmlResponse;
     }
 
     for (const value of Object.values(response)) {
-      if (!value || Array.isArray(value) || typeof value !== 'object') {
+      if (!this.isObjectRecord(value)) {
         continue;
       }
 
-      const nestedNode = (value as Record<string, unknown>)[key];
-      if (nestedNode && !Array.isArray(nestedNode) && typeof nestedNode === 'object') {
+      const nestedNode = value[key];
+      if (this.isObjectRecord(nestedNode)) {
         return nestedNode as ProxyXmlResponse;
       }
     }
@@ -216,6 +251,32 @@ export class DbgpProxyClient {
     return fallbackMessage;
   }
 
+  /**
+   * Reject malformed proxy port values early so registration logs do not contain a fake port number.
+   */
+  private parseOptionalPort(value?: string): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const port = parseInt(value, 10);
+    if (Number.isNaN(port) || port <= 0) {
+      throw new Error(`DBGp proxy returned an invalid port: ${value}`);
+    }
+
+    return port;
+  }
+
+  /**
+   * Narrow unknown parser output to a plain object before reading XML attributes from it.
+   */
+  private isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  /**
+   * Escape command arguments so proxy commands survive spaces and shell-sensitive characters.
+   */
   private escapeArg(value: string): string {
     if (value.includes('\0')) {
       throw new Error('DBGp proxy arguments cannot contain null bytes');

--- a/src/dbgp/proxy.ts
+++ b/src/dbgp/proxy.ts
@@ -1,0 +1,206 @@
+/**
+ * DBGp Proxy Client
+ * Registers the MCP server with a DBGp proxy using proxyinit/proxystop.
+ */
+
+import * as net from 'net';
+import { XMLParser } from 'fast-xml-parser';
+
+export interface DbgpProxyConfig {
+  host: string;
+  port: number;
+  ideKey: string;
+  allowFallback: boolean;
+}
+
+export interface ProxyRegistration {
+  ideKey: string;
+  address?: string;
+  port?: number;
+}
+
+interface ProxyXmlResponse {
+  success?: string;
+  '@_success'?: string;
+  '@_idekey'?: string;
+  '@_address'?: string;
+  '@_port'?: string;
+  error?: {
+    '@_id'?: string;
+    message?: string | { '#text'?: string };
+  };
+}
+
+export class DbgpProxyClient {
+  private readonly xmlParser: XMLParser;
+  private registration: ProxyRegistration | null = null;
+
+  constructor(private readonly config: DbgpProxyConfig) {
+    this.xmlParser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      textNodeName: '#text',
+      parseAttributeValue: false,
+      trimValues: true,
+    });
+  }
+
+  get isRegistered(): boolean {
+    return this.registration !== null;
+  }
+
+  get currentRegistration(): ProxyRegistration | null {
+    return this.registration;
+  }
+
+  async register(listenPort: number, supportsMultipleSessions: boolean): Promise<ProxyRegistration> {
+    const multipleSessionsFlag = supportsMultipleSessions ? '1' : '0';
+    const response = await this.sendProxyCommand(
+      `proxyinit -p ${listenPort} -k ${this.escapeArg(this.config.ideKey)} -m ${multipleSessionsFlag}`
+    );
+
+    const proxyInit = this.getResponseNode(response, 'proxyinit');
+    const success = proxyInit['@_success'] ?? proxyInit.success ?? '0';
+    if (success !== '1') {
+      throw new Error(this.getErrorMessage(proxyInit, 'DBGp proxy registration failed'));
+    }
+
+    this.registration = {
+      ideKey: proxyInit['@_idekey'] || this.config.ideKey,
+      address: proxyInit['@_address'],
+      port: proxyInit['@_port'] ? parseInt(proxyInit['@_port'], 10) : undefined,
+    };
+
+    return this.registration;
+  }
+
+  async unregister(): Promise<void> {
+    if (!this.registration) {
+      return;
+    }
+
+    const response = await this.sendProxyCommand(
+      `proxystop -k ${this.escapeArg(this.registration.ideKey)}`
+    );
+
+    const proxyStop = this.getResponseNode(response, 'proxystop');
+    const success = proxyStop['@_success'] ?? proxyStop.success ?? '0';
+    if (success !== '1') {
+      throw new Error(this.getErrorMessage(proxyStop, 'DBGp proxy unregistration failed'));
+    }
+
+    this.registration = null;
+  }
+
+  private async sendProxyCommand(command: string): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection(
+        {
+          host: this.config.host,
+          port: this.config.port,
+        },
+        () => {
+          socket.write(`${command}\0`);
+        }
+      );
+
+      let response = '';
+      let settled = false;
+
+      const finish = (handler: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        handler();
+      };
+
+      const timeout = setTimeout(() => {
+        finish(() => {
+          socket.destroy();
+          reject(new Error(`DBGp proxy command timed out: ${command}`));
+        });
+      }, 10000);
+
+      socket.setEncoding('utf8');
+
+      socket.on('data', (chunk) => {
+        response += chunk;
+      });
+
+      socket.on('error', (error) => {
+        finish(() => {
+          reject(error);
+        });
+      });
+
+      socket.on('end', () => {
+        finish(() => {
+          try {
+            resolve(this.parseResponse(response));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+
+      socket.on('close', (hadError) => {
+        if (hadError || settled) {
+          return;
+        }
+
+        finish(() => {
+          try {
+            resolve(this.parseResponse(response));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+    });
+  }
+
+  private parseResponse(response: string): Record<string, unknown> {
+    const payload = response.replace(/\0/g, '').trim();
+    if (!payload) {
+      throw new Error('DBGp proxy returned an empty response');
+    }
+
+    return this.xmlParser.parse(payload) as Record<string, unknown>;
+  }
+
+  private getResponseNode(response: Record<string, unknown>, key: string): ProxyXmlResponse {
+    const node = response[key];
+    if (!node || Array.isArray(node) || typeof node !== 'object') {
+      throw new Error(`Unexpected DBGp proxy response: missing <${key}> root element`);
+    }
+
+    return node as ProxyXmlResponse;
+  }
+
+  private getErrorMessage(response: ProxyXmlResponse, fallbackMessage: string): string {
+    const error = response.error;
+    if (!error) {
+      return fallbackMessage;
+    }
+
+    const message = typeof error.message === 'string' ? error.message : error.message?.['#text'];
+    const errorId = error['@_id'];
+    if (message && errorId) {
+      return `${fallbackMessage} (${errorId}): ${message}`;
+    }
+    if (message) {
+      return `${fallbackMessage}: ${message}`;
+    }
+    return fallbackMessage;
+  }
+
+  private escapeArg(value: string): string {
+    if (/[\\s"\\\\]/.test(value)) {
+      return `"${value.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\"')}"`;
+    }
+
+    return value;
+  }
+}

--- a/src/dbgp/proxy.ts
+++ b/src/dbgp/proxy.ts
@@ -47,7 +47,10 @@ export class DbgpProxyClient {
   private readonly xmlParser: XMLParser;
   private registration: ProxyRegistration | null = null;
 
-  constructor(private readonly config: DbgpProxyConfig) {
+  constructor(
+    private readonly config: DbgpProxyConfig,
+    private readonly commandTimeout: number = 10000
+  ) {
     this.xmlParser = new XMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: '@_',
@@ -76,8 +79,9 @@ export class DbgpProxyClient {
    */
   async register(listenPort: number, supportsMultipleSessions: boolean): Promise<ProxyRegistration> {
     const multipleSessionsFlag = supportsMultipleSessions ? '1' : '0';
+    const ideKey = this.validateIdeKey(this.config.ideKey);
     const response = await this.sendProxyCommand(
-      `proxyinit -p ${listenPort} -k ${this.escapeArg(this.config.ideKey)} -m ${multipleSessionsFlag}`
+      `proxyinit -p ${listenPort} -k ${ideKey} -m ${multipleSessionsFlag}`
     );
 
     const proxyInit = this.getResponseNode(response, 'proxyinit');
@@ -103,8 +107,9 @@ export class DbgpProxyClient {
       return;
     }
 
+    const ideKey = this.validateIdeKey(this.registration.ideKey);
     const response = await this.sendProxyCommand(
-      `proxystop -k ${this.escapeArg(this.registration.ideKey)}`
+      `proxystop -k ${ideKey}`
     );
 
     const proxyStop = this.getResponseNode(response, 'proxystop');
@@ -166,7 +171,7 @@ export class DbgpProxyClient {
           socket.destroy();
           reject(new Error(`${commandName} timed out waiting for a DBGp proxy response`));
         });
-      }, 10000);
+      }, this.commandTimeout);
 
       socket.setEncoding('utf8');
 
@@ -275,14 +280,16 @@ export class DbgpProxyClient {
   }
 
   /**
-   * Escape command arguments so proxy commands survive spaces and shell-sensitive characters.
+   * Keep IDE keys compatible with the reference proxy, which splits on spaces and does not unescape quoted values.
    */
-  private escapeArg(value: string): string {
+  private validateIdeKey(value: string): string {
     if (value.includes('\0')) {
       throw new Error('DBGp proxy arguments cannot contain null bytes');
     }
     if (/[\s"\\]/.test(value)) {
-      return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+      throw new Error(
+        'DBGp proxy IDE keys must not contain spaces, quotes, or backslashes because the reference proxy does not parse escaped arguments.'
+      );
     }
 
     return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig } from './config.js';
+import { DbgpProxyClient } from './dbgp/proxy.js';
 import { DbgpServer } from './dbgp/server.js';
 import { SessionManager } from './session/manager.js';
 import { registerAllTools, createToolsContext, ToolsContext } from './tools/index.js';
@@ -15,6 +16,7 @@ import { logger } from './utils/logger.js';
 
 async function main() {
   const config = loadConfig();
+  const proxyConfig = config.proxy;
 
   logger.info('Starting Xdebug MCP Server...');
   logger.debug('Configuration:', config);
@@ -27,6 +29,7 @@ async function main() {
     socketPath: config.dbgpSocketPath,
     commandTimeout: config.commandTimeout,
   });
+  const dbgpProxyClient = proxyConfig ? new DbgpProxyClient(proxyConfig) : null;
 
   // Create tools context early so we can access pendingBreakpoints
   const toolsContext: ToolsContext = createToolsContext(sessionManager);
@@ -166,6 +169,29 @@ async function main() {
     process.exit(1);
   }
 
+  if (dbgpProxyClient && proxyConfig) {
+    try {
+      const registration = await dbgpProxyClient.register(config.dbgpPort, true);
+      const proxyTarget = registration.address && registration.port
+        ? `${registration.address}:${registration.port}`
+        : 'unknown proxy endpoint';
+      logger.info(
+        `Registered IDE key '${registration.ideKey}' with DBGp proxy ${proxyConfig.host}:${proxyConfig.port} (proxy server: ${proxyTarget})`
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to register with DBGp proxy ${proxyConfig.host}:${proxyConfig.port}: ${error instanceof Error ? error.message : String(error)}`
+      );
+
+      if (!proxyConfig.allowFallback) {
+        await dbgpServer.stop();
+        process.exit(1);
+      }
+
+      logger.warn('Continuing in direct-listener mode because DBGP_PROXY_ALLOW_FALLBACK is enabled');
+    }
+  }
+
   // Initialize MCP server
   const mcpServer = new McpServer({
     name: 'xdebug-mcp',
@@ -196,6 +222,16 @@ async function main() {
 
     logger.info('Shutting down...');
     sessionManager.closeAllSessions();
+    if (dbgpProxyClient?.isRegistered && proxyConfig) {
+      try {
+        await dbgpProxyClient.unregister();
+        logger.info(`Removed DBGp proxy registration for IDE key '${proxyConfig?.ideKey}'`);
+      } catch (error) {
+        logger.warn(
+          `Failed to remove DBGp proxy registration: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
     await dbgpServer.stop();
     process.exit(0);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,20 @@ import { logger } from './utils/logger.js';
  */
 async function main() {
   const config = loadConfig();
-  const proxyConfig = config.proxy;
+  const proxyIntegration = config.proxy
+    ? {
+        config: config.proxy,
+        // Reuse the server command timeout so proxy control traffic follows the same operator expectation.
+        client: new DbgpProxyClient(
+          {
+            host: config.proxy.host,
+            port: config.proxy.port,
+            ideKey: config.proxy.ideKey,
+          },
+          config.commandTimeout
+        ),
+      }
+    : null;
 
   logger.info('Starting Xdebug MCP Server...');
   logger.debug('Configuration:', config);
@@ -33,13 +46,6 @@ async function main() {
     socketPath: config.dbgpSocketPath,
     commandTimeout: config.commandTimeout,
   });
-  const dbgpProxyClient = proxyConfig
-    ? new DbgpProxyClient({
-        host: proxyConfig.host,
-        port: proxyConfig.port,
-        ideKey: proxyConfig.ideKey,
-      })
-    : null;
 
   // Create tools context early so we can access pendingBreakpoints
   const toolsContext: ToolsContext = createToolsContext(sessionManager);
@@ -179,7 +185,8 @@ async function main() {
     process.exit(1);
   }
 
-  if (dbgpProxyClient && proxyConfig) {
+  if (proxyIntegration) {
+    const { client: dbgpProxyClient, config: proxyConfig } = proxyIntegration;
     try {
       // Register only after the TCP listener is live so the proxy never routes sessions to a dead endpoint.
       const registration = await dbgpProxyClient.register(config.dbgpPort, true);
@@ -233,11 +240,12 @@ async function main() {
 
     logger.info('Shutting down...');
     sessionManager.closeAllSessions();
-    if (dbgpProxyClient?.isRegistered && proxyConfig) {
+    if (proxyIntegration?.client.isRegistered) {
+      const { client: dbgpProxyClient, config: proxyConfig } = proxyIntegration;
       try {
         // Unregister first so the proxy stops routing new sessions while this process is exiting.
         await dbgpProxyClient.unregister();
-        logger.info(`Removed DBGp proxy registration for IDE key '${proxyConfig?.ideKey}'`);
+        logger.info(`Removed DBGp proxy registration for IDE key '${proxyConfig.ideKey}'`);
       } catch (error) {
         logger.warn(
           `Failed to remove DBGp proxy registration: ${error instanceof Error ? error.message : String(error)}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,13 @@ async function main() {
     socketPath: config.dbgpSocketPath,
     commandTimeout: config.commandTimeout,
   });
-  const dbgpProxyClient = proxyConfig ? new DbgpProxyClient(proxyConfig) : null;
+  const dbgpProxyClient = proxyConfig
+    ? new DbgpProxyClient({
+        host: proxyConfig.host,
+        port: proxyConfig.port,
+        ideKey: proxyConfig.ideKey,
+      })
+    : null;
 
   // Create tools context early so we can access pendingBreakpoints
   const toolsContext: ToolsContext = createToolsContext(sessionManager);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,13 @@ import { loadConfig } from './config.js';
 import { DbgpProxyClient } from './dbgp/proxy.js';
 import { DbgpServer } from './dbgp/server.js';
 import { SessionManager } from './session/manager.js';
+import type { DebugSession } from './session/session.js';
 import { registerAllTools, createToolsContext, ToolsContext } from './tools/index.js';
 import { logger } from './utils/logger.js';
 
+/**
+ * Start the MCP server and optionally register its DBGp listener with an external proxy.
+ */
 async function main() {
   const config = loadConfig();
   const proxyConfig = config.proxy;
@@ -46,7 +50,7 @@ async function main() {
     logger.info(`  File: ${connection.initPacket?.fileUri}`);
     logger.info(`  IDE Key: ${connection.initPacket?.ideKey}`);
 
-    let session: any = null;
+    let session: DebugSession | null = null;
 
     try {
       // === PHASE 1: Session Creation ===
@@ -177,6 +181,7 @@ async function main() {
 
   if (dbgpProxyClient && proxyConfig) {
     try {
+      // Register only after the TCP listener is live so the proxy never routes sessions to a dead endpoint.
       const registration = await dbgpProxyClient.register(config.dbgpPort, true);
       const proxyTarget = registration.address && registration.port
         ? `${registration.address}:${registration.port}`
@@ -230,6 +235,7 @@ async function main() {
     sessionManager.closeAllSessions();
     if (dbgpProxyClient?.isRegistered && proxyConfig) {
       try {
+        // Unregister first so the proxy stops routing new sessions while this process is exiting.
         await dbgpProxyClient.unregister();
         logger.info(`Removed DBGp proxy registration for IDE key '${proxyConfig?.ideKey}'`);
       } catch (error) {


### PR DESCRIPTION
# Feature: add DBGp proxy registration support

## Summary

This PR adds optional DBGp proxy registration to `xdebug-mcp` so it can register itself with an existing DBGp proxy on startup and unregister on shutdown.

This makes it possible to keep PHP/Xdebug pointed at the proxy while routing matching IDE-key sessions back to `xdebug-mcp`, similar to how a traditional IDE integrates with a DBGp proxy.

## Expected behavior

When DBGp proxy environment variables are configured, `xdebug-mcp` should:

- start its local TCP listener on a dedicated callback port
- register with the DBGp proxy using its configured IDE key
- receive proxied sessions that match that IDE key
- unregister cleanly on shutdown

If proxy registration fails:

- startup should fail when `DBGP_PROXY_ALLOW_FALLBACK=false`
- startup should continue in direct-listener mode when `DBGP_PROXY_ALLOW_FALLBACK=true`
- when fallback is enabled, `xdebug-mcp` should still start successfully and behave as a normal direct listener even though proxy registration did not succeed

## Actual behavior before this PR

`xdebug-mcp` only supported direct listener mode over TCP or Unix sockets.

The practical challenge was that I was still using PhpStorm and Xdebug in the same workflow, and `xdebug-mcp` would conflict with PhpStorm's listening port of `9003`.

Without proxy registration, `xdebug-mcp` needed its own direct listener setup, which made it awkward to use alongside PhpStorm when both tools needed to participate in debugging without fighting over the same connection target.

## What changed

This PR adds:

1. **Proxy configuration support** in `src/config.ts`
   - parses `DBGP_PROXY_HOST`, `DBGP_PROXY_PORT`, `DBGP_IDEKEY`, and `DBGP_PROXY_ALLOW_FALLBACK`
   - requires the full proxy configuration when any proxy variable is present
   - rejects Unix socket mode when proxy registration is enabled

2. **A DBGp proxy client implementation** in `src/dbgp/proxy.ts`
   - sends `proxyinit -p <XDEBUG_PORT> -k <DBGP_IDEKEY> -m 1`
   - sends `proxystop -k <DBGP_IDEKEY>` on shutdown
   - parses proxy responses and surfaces registration errors clearly

3. **Startup and shutdown integration** in `src/index.ts`
   - attempts proxy registration during server startup
   - respects `DBGP_PROXY_ALLOW_FALLBACK`
   - unregisters from the proxy during shutdown when registration succeeded

4. **Documentation and example updates**
   - adds README guidance for DBGp proxy usage
   - documents the requirement for unique `DBGP_IDEKEY` and `XDEBUG_PORT` values per running agent
   - updates the sample MCP config to show a proxy-enabled Claude example

## Multi-agent note

While working through this feature, it became clear that multiple AI agents should not share the same DBGp registration identity.

For concurrent agent setups, each `xdebug-mcp` instance should use its own unique values, for example:

- Warp: `DBGP_IDEKEY=xdebug-warp`, `XDEBUG_PORT=9006`
- Claude Code: `DBGP_IDEKEY=xdebug-claude`, `XDEBUG_PORT=9007`
- Codex: `DBGP_IDEKEY=xdebug-codex`, `XDEBUG_PORT=9008`

Because of that uniqueness requirement, `xdebug-mcp` should be registered directly in each agent rather than installed behind an MCP proxy or bundler when per-agent DBGp registrations are needed.

## Impact

- enables `xdebug-mcp` to participate in existing DBGp proxy workflows
- makes it easier to route Xdebug sessions to AI tooling by IDE key
- adds clearer startup failure behavior for misconfigured proxy environments
- documents the safe multi-agent configuration pattern for Warp, Claude Code, and Codex

## How to use

This feature requires a running DBGp proxy binary. `xdebug-mcp` registers with an existing proxy, but it does not embed or launch the proxy itself.

Official reference:
- https://xdebug.org/docs/dbgpProxy

Example environment:

```json
{
  "mcpServers": {
    "xdebug": {
      "command": "node",
      "args": ["/absolute/path/to/xdebug-mcp/dist/index.js"],
      "env": {
        "XDEBUG_PORT": "9007",
        "XDEBUG_HOST": "0.0.0.0",
        "DBGP_PROXY_HOST": "127.0.0.1",
        "DBGP_PROXY_PORT": "9001",
        "DBGP_IDEKEY": "xdebug-claude",
        "DBGP_PROXY_ALLOW_FALLBACK": "false",
        "LOG_LEVEL": "info"
      }
    }
  }
}
```

On the PHP/Xdebug side, keep `xdebug.client_host` and `xdebug.client_port` pointed at the DBGp proxy, then trigger the request with the matching IDE key.

## Notes

- a DBGp proxy binary must already be installed and running or the proxy registration flow will not work
- the official Xdebug DBGp proxy reference and download guidance is here: https://xdebug.org/docs/dbgpProxy
- proxy registration requires TCP listener mode and does not work with `XDEBUG_SOCKET_PATH`
- `XDEBUG_PORT` is the callback port for `xdebug-mcp`, not the proxy's client-facing port
- if proxy registration fails and fallback is enabled, `xdebug-mcp` still starts and behaves as a normal direct listener
- this PR includes both the proxy registration implementation and the follow-up documentation/example updates for unique multi-agent registrations
